### PR TITLE
In each Derby app bundle, prune views from other apps

### DIFF
--- a/lib/DerbyViewPlugin.js
+++ b/lib/DerbyViewPlugin.js
@@ -16,7 +16,8 @@ DerbyViewsPlugin.prototype.apply = function(compiler) {
   const virtualModules = new VirtualModulesPlugin({});
   virtualModules.apply(compiler);
   const { apps, rootPath } = this;
-  compiler.hooks.compilation.tap('DerbyViewsPlugin', function(ctx) {
+  compiler.hooks.compilation.tap('DerbyViewsPlugin', function(compilation) {
+    // Add serialized Derby views for all apps as virtual modules.
     const originalNodeEnv = process.env.NODE_ENV;
     // hack to work around Derby listening for changes and holding process open
     process.env.NODE_ENV = 'production';
@@ -30,6 +31,33 @@ DerbyViewsPlugin.prototype.apply = function(compiler) {
       virtualModules.writeModule(modulePath, viewSource);
     });
     process.env.NODE_ENV = originalNodeEnv;
+
+    // When Webpack detects requires with partially-dynamic paths, it will
+    // include all potentially matching modules as dependencies. The views
+    // are required from derby/lib/App.js, so views for all apps are included
+    // in all app bundles.
+    //
+    // This uses the optimizeChunks hook to prune non-relevant view files from
+    // each app's bundle, so that each app bundle only includes its own views.
+    compilation.hooks.optimizeChunks.tap(
+      'DerbyViewsPlugin',
+      (chunks) => {
+        const chunkGraph = compilation.chunkGraph;
+        for (const chunk of chunks) {
+          const viewModulesForOtherApps = [];
+          for (const module of chunkGraph.getChunkModules(chunk)) {
+            if (module.request?.endsWith(viewsSuffix)) {
+              if (!module.request.endsWith(`/${chunk.name}${viewsSuffix}`)) {
+                viewModulesForOtherApps.push(module);
+              }
+            }
+          }
+          for (const moduleToRemove of viewModulesForOtherApps) {
+            chunkGraph.disconnectChunkAndModule(chunk, moduleToRemove);
+          }
+        }
+      }
+    );
   });
 }
 


### PR DESCRIPTION
When Webpack detects [requires with partially-dynamic paths](https://webpack.js.org/guides/dependency-management/#require-with-expression), it will include all potentially matching modules as dependencies. The views are required from derby/lib/App.js, so views for all apps are included in all app bundles.

This change uses the optimizeChunks hook to prune non-relevant view files from each app's bundle, so that each app bundle only includes its own views.