### PR TITLE
Webpack hot module reload

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,11 @@ const webpackConfig = require('./webpack.config');
 function derbyWebpack(apps, rootDir) {
   const config = () => webpackConfig(webpack, apps, rootDir);
 
-  const hmrConfig = webpackConfig(webpack, apps, rootDir, {hotModuleReplacement: true});
-  const compiler = webpack(hmrConfig);
-  const hotReloadMiddleware = () => webpackHotMiddleware(webpackCompiler);
-
-  const devMiddleware = () => webpackMiddleware(compiler, {
+  const hotReloadMiddleware = config => webpackHotMiddleware(webpack(config));
+  const devMiddleware = config => webpackMiddleware(webpack(config), {
     serverSideRender: true,
     index: false,
-    publicPath: hmrConfig.output.publicPath,
+    publicPath: config.output.publicPath,
   });
 
   return {

--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ const webpackConfig = require('./webpack.config');
 function derbyWebpack(apps, rootDir) {
   const config = () => webpackConfig(webpack, apps, rootDir);
 
-  const hotReloadMiddleware = config => webpackHotMiddleware(webpack(config));
-  const devMiddleware = config => webpackMiddleware(webpack(config), {
+  const hotReloadMiddleware = resolvedConfig => webpackHotMiddleware(webpack(resolvedConfig));
+  const devMiddleware = resolvedConfig => webpackMiddleware(webpack(resolvedConfig), {
     serverSideRender: true,
     index: false,
-    publicPath: config.output.publicPath,
+    publicPath: resolvedConfig.output.publicPath,
   });
 
   return {

--- a/index.js
+++ b/index.js
@@ -6,15 +6,15 @@ const webpackConfig = require('./webpack.config');
 
 function derbyWebpack(apps, rootDir) {
   const config = () => webpackConfig(webpack, apps, rootDir);
-  const resovledConfig = config();
-  const compiler = webpack(resovledConfig);
 
+  const hmrConfig = webpackConfig(webpack, apps, rootDir, {hotModuleReplacement: true});
+  const compiler = webpack(hmrConfig);
   const hotReloadMiddleware = () => webpackHotMiddleware(webpackCompiler);
 
   const devMiddleware = () => webpackMiddleware(compiler, {
     serverSideRender: true,
     index: false,
-    publicPath: resovledConfig.output.publicPath,
+    publicPath: hmrConfig.output.publicPath,
   });
 
   return {

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -5,7 +5,6 @@
  */
 const chokidar = require('chokidar');
 const resolve = require('path').resolve;
-const EvenEmitter = require('events').EventEmitter;
 
 module.exports = function createWatcher(path) {
   return new FileWatcher(path);
@@ -17,11 +16,11 @@ function FileWatcher(path) {
   const watcher = chokidar.watch(path, options);
 
   watcher.on('ready', function() {
-    const apppath = resolve(path);
+    const appPath = resolve(path);
     watcher.on('change', function(subpath) {
       Object.keys(require.cache).forEach(function(id) {
         // CACHE INVALIDATION
-        if (id.startsWith(apppath)) {
+        if (id.startsWith(appPath)) {
           delete require.cache[id];
         }
       });

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -4,17 +4,21 @@
  *  does not watch anything in node_modules/ 
  */
 const chokidar = require('chokidar');
-const p = require('path');
+const resolve = require('path').resolve;
+const EvenEmitter = require('events').EventEmitter;
 
-module.exports = FileWatcher;
+module.exports = function createWatcher(path) {
+  return new FileWatcher(path);
+};
 
 function FileWatcher(path) {  
   const options = {ignored:['*.html']};
 
   const watcher = chokidar.watch(path, options);
-    watcher.on('ready', function() {
-    const apppath = p.resolve(path);
-    watcher.on('all', function(type, subpath) {
+
+  watcher.on('ready', function() {
+    const apppath = resolve(path);
+    watcher.on('change', function(subpath) {
       Object.keys(require.cache).forEach(function(id) {
         // CACHE INVALIDATION
         if (id.startsWith(apppath)) {
@@ -27,7 +31,11 @@ function FileWatcher(path) {
   this.watcher = watcher;
 }
 
+FileWatcher.prototype.on = function (event, callback) {
+  this.watcher.on(event, callback);
+  return this;
+}
+
 FileWatcher.prototype.close = function () {
   this.watcher.close();
 }
- 

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -4,7 +4,7 @@
  *  does not watch anything in node_modules/ 
  */
 const chokidar = require('chokidar');
-const path = require('path');
+const p = require('path');
 
 module.exports = FileWatcher;
 
@@ -13,7 +13,7 @@ function FileWatcher(path) {
 
   const watcher = chokidar.watch(path, options);
     watcher.on('ready', function() {
-    const apppath = path.resolve(path);
+    const apppath = p.resolve(path);
     watcher.on('all', function(type, subpath) {
       Object.keys(require.cache).forEach(function(id) {
         // CACHE INVALIDATION

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -20,6 +20,27 @@ function plugin(app, options) {
     }
   }
 
+  function middlewareAssets(page) {
+    const { devMiddleware } = page.res.locals.webpack;
+    const jsonWebpackStats = devMiddleware.stats.toJson();
+    const { assetsByChunkName } = jsonWebpackStats;
+    return Object.values(assetsByChunkName)
+      .flatMap(normalizeAssets)
+      .filter(key => sourcesRe.test(key));
+  }
+  
+  function readManifestAssets(filepath) {
+    if (!existsSync(filepath)) {
+      console.error('No manifest.json file found, and webpack middleware not available. Run pack to build static bundle before starting');
+      throw new Error('Missing manifest.json');
+    }
+    const manifestString = readFileSync(filepath, 'utf-8');
+    const assetMap = JSON.parse(manifestString);
+    return Object.entries(assetMap)
+      .filter(([key]) => sourcesRe.test(key))
+      .map(([_, value]) => value);
+  }
+
   app.on('htmlDone', (page) => {
     console.log('===== 🚀 HTML_DONE');
     const scriptCrossOrigin = page.app.scriptCrossOrigin || false;
@@ -35,26 +56,6 @@ function plugin(app, options) {
   });
 }
 
-function middlewareAssets(page) {
-  const { devMiddleware } = page.res.locals.webpack;
-  const jsonWebpackStats = devMiddleware.stats.toJson();
-  const { assetsByChunkName } = jsonWebpackStats;
-  return Object.values(assetsByChunkName)
-    .flatMap(normalizeAssets)
-    .filter(key => sourcesRe.test(key));
-}
-
-function readManifestAssets(filepath) {
-  if (!existsSync(filepath)) {
-    console.error('No manifest.json file found, and webpack middleware not available. Run pack to build static bundle before starting');
-    throw new Error('Missing manifest.json');
-  }
-  const manifestString = readFileSync(filepath, 'utf-8');
-  const assetMap = JSON.parse(manifestString);
-  return Object.entries(assetMap)
-    .filter(([key]) => sourcesRe.test(key))
-    .map(([_, value]) => value);
-}
 
 function isObject(x) {
   return typeof x === 'object' && x !== null;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -21,8 +21,8 @@ function plugin(app, options) {
   }
 
   App.prototype._views = function () {
-    const appname = this.name;
-    return require(`derby/lib/${appname}__views`);
+    const appName = this.name;
+    return require(`derby/lib/${appName}__views`);
   }
 
   function middlewareAssets(page) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -14,7 +14,7 @@ function plugin(app, options) {
   const sourcesRe = new RegExp(`(${app.name}|${app.name}_views|vendors|common|runtime).*\.js$`);
 
   App.prototype.writeScripts = function(backend, dir, options, cb) {
-    // no-op function
+    this._autoRefresh(backend);
     if (typeof cb === 'function') {
       cb();
     }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -42,14 +42,12 @@ function plugin(app, options) {
   }
 
   app.on('htmlDone', (page) => {
-    console.log('===== 🚀 HTML_DONE');
     const scriptCrossOrigin = page.app.scriptCrossOrigin || false;
     if (page.res.locals.webpack) {
       assets = middlewareAssets(page);
     } else {
       assets = readManifestAssets('./public/manifest.json');
     }
-    console.log('ASSETS', assets);
     const scriptTags = assets.map(path => `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${path}" type="text/javascript"></script>`)
       .join('\n');
     page.res.write(scriptTags);
@@ -66,8 +64,4 @@ function normalizeAssets(assets) {
     return Object.values(assets);
   }
   return Array.isArray(assets) ? assets : [assets];
-}
-
-function includeJsAssets(path) {
-  return path.endsWith(".js") && !path.includes('hot-update');
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -11,7 +11,7 @@ function plugin(app, options) {
   }
   const { derby } = app;
   const { App, util } = derby;
-  const sourcesRe = new RegExp(`(${app.name}|${app.name}_views|vendors|common|runtime)\.js$`);
+  const sourcesRe = new RegExp(`(${app.name}|${app.name}_views|vendors|common|runtime).*\.js$`);
 
   App.prototype.writeScripts = function(backend, dir, options, cb) {
     // no-op function
@@ -21,38 +21,40 @@ function plugin(app, options) {
   }
 
   app.on('htmlDone', (page) => {
+    console.log('===== 🚀 HTML_DONE');
     const scriptCrossOrigin = page.app.scriptCrossOrigin || false;
-
     if (page.res.locals.webpack) {
-      const { devMiddleware } = page.res.locals.webpack;
-      const jsonWebpackStats = devMiddleware.stats.toJson();
-      const { assetsByChunkName } = jsonWebpackStats;
-      const chunkEntries = Object.values(assetsByChunkName);
-      const scriptTags = chunkEntries.map(entry => normalizeAssets(entry))
-        .filter(([key]) => sourcesRe.test(key))
-        .flat()
-        .map(path => `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${path}"></script>`)
-        .join('\n');
-      page.res.write(scriptTags);
+      assets = middlewareAssets(page);
     } else {
-      // write from manifest for static assets
-      if (!existsSync('./public/manifest.json')) {
-        console.error('No manifest.json file found, and webpack middleware not available. Run pack to build static bundle before starting');
-        throw new Error('Missing manifest.json');
-      }
-      const manifestString = readFileSync('./public/manifest.json', 'utf-8');
-      const manifest = JSON.parse(manifestString);
-      ASSETS = Object.entries(manifest)
-        .filter(([key]) => sourcesRe.test(key))
-        .map(([_, value]) => value);
-      const scriptTags = ASSETS.map(path => `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${path}"></script>`)
-        .join('\n');
-      page.res.write(scriptTags);
+      assets = readManifestAssets('./public/manifest.json');
     }
+    console.log('ASSETS', assets);
+    const scriptTags = assets.map(path => `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${path}" type="text/javascript"></script>`)
+      .join('\n');
+    page.res.write(scriptTags);
   });
 }
 
-let ASSETS = [];
+function middlewareAssets(page) {
+  const { devMiddleware } = page.res.locals.webpack;
+  const jsonWebpackStats = devMiddleware.stats.toJson();
+  const { assetsByChunkName } = jsonWebpackStats;
+  return Object.values(assetsByChunkName)
+    .flatMap(normalizeAssets)
+    .filter(key => sourcesRe.test(key));
+}
+
+function readManifestAssets(filepath) {
+  if (!existsSync(filepath)) {
+    console.error('No manifest.json file found, and webpack middleware not available. Run pack to build static bundle before starting');
+    throw new Error('Missing manifest.json');
+  }
+  const manifestString = readFileSync(filepath, 'utf-8');
+  const assetMap = JSON.parse(manifestString);
+  return Object.entries(assetMap)
+    .filter(([key]) => sourcesRe.test(key))
+    .map(([_, value]) => value);
+}
 
 function isObject(x) {
   return typeof x === 'object' && x !== null;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -20,6 +20,11 @@ function plugin(app, options) {
     }
   }
 
+  App.prototype._views = function () {
+    const appname = this.name;
+    return require(`derby/lib/${appname}__views`);
+  }
+
   function middlewareAssets(page) {
     const { devMiddleware } = page.res.locals.webpack;
     const jsonWebpackStats = devMiddleware.stats.toJson();

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -4,48 +4,48 @@ const fileWatcher = require('./FileWatcher');
 
 module.exports = reloader;
 
-function reloader(apppath, initFn) {
-  if (!path.isAbsolute(apppath)) {
+function reloader(appPath, initFn) {
+  if (!path.isAbsolute(appPath)) {
     throw new Error('Reloader requires an absolute path to module');
   }
 
-  let m = null;
+  let appModule = null;
   let instance = null;
 
-  m = require(apppath);
-  if (initFn && !instance) {
-    instance = initFn(m);
+  appModule = require(appPath);
+  if (initFn) {
+    appInstance = initFn(appModule);
   } else {
-    instance = m;
+    appInstance = appModule;
   }
 
   if (!process.env.DERBY_HMR) {
-    // return un-proxied instance
+    // return un-proxied appInstance
     // if DERBY_HMR is not enabled
-    return instance;
+    return appInstance;
   }
 
-  const filepath = require.resolve(apppath);
-  const resolvedPath = path.dirname(filepath) === apppath
-    ? apppath   // apppath resolves a directory, whatch all
-    : filepath; // apppath resolves a filename, watch file
+  const filepath = require.resolve(appPath);
+  const resolvedPath = path.dirname(filepath) === appPath
+    ? appPath   // appPath resolves a directory, watch all
+    : filepath; // appPath resolves a filename, watch file
   fileWatcher(resolvedPath);
 
   const handler = (req, res, next) => {
-    if (!require.cache[apppath]) {
+    if (!require.cache[appPath]) {
       // has been evicted form require.cache
       // ensure initalization is handled again
-      instance = null;
+      appInstance = null;
     }
-    if (!instance) {
-      m = require(apppath);
+    if (!appInstance) {
+      appModule = require(appPath);
       if (initFn) {
-        instance = initFn(m);
+        appInstance = initFn(appModule);
       } else {
-        instance = m;
+        appInstance = appModule;
       }
     }
-    instance(req, res, next);
+    appInstance(req, res, next);
   }
 
   const proxy = new Proxy(handler, {

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -1,0 +1,36 @@
+const path = requrie('node:path');
+const fs = require('node:fs');
+const fileWatcher = require('./FileWatcher');
+
+module.exports = reloader;
+
+function reloader(apppath, initFn) {
+  filepath = require.resolve(apppath)
+  resolvedPath = filepath
+  fileWatcher(resolvedPath);
+
+  let m = null;
+  let instance = null;
+
+  m = require(apppath);
+  if (initFn && !instance) {
+    instance = initFn(m);
+  } else {
+    instance = m;
+  }
+
+  return (req, res, next) => {
+    if (!require.cache[apppath]) {
+      instance = null;
+    }
+    if (!instance) {
+      m = require(apppath);
+      if (initFn) {
+        instance = initFn(m);
+      } else {
+        instance = m;
+      }
+    }
+    instance(req, res, next)
+  }
+}

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -1,12 +1,18 @@
-const path = requrie('node:path');
 const fs = require('node:fs');
+const path = require('node:path');
 const fileWatcher = require('./FileWatcher');
 
 module.exports = reloader;
 
 function reloader(apppath, initFn) {
-  filepath = require.resolve(apppath)
-  resolvedPath = filepath
+  if (!path.isAbsolute(apppath)) {
+    throw new Error('Reloader requires an absolute path to module');
+  }
+
+  const filepath = require.resolve(apppath);
+  const resolvedPath = path.dirname(filepath) === apppath
+    ? apppath   // apppath resolves a directory, whatch all
+    : filepath; // apppath resolves a filename, watch file
   fileWatcher(resolvedPath);
 
   let m = null;
@@ -19,8 +25,16 @@ function reloader(apppath, initFn) {
     instance = m;
   }
 
-  return (req, res, next) => {
+  if (!process.env.DERBY_HMR) {
+    // return un-proxied instance
+    // if DERBY_HMR is not enabled
+    return instance;
+  }
+
+  const handler = (req, res, next) => {
     if (!require.cache[apppath]) {
+      // has been evicted form require.cache
+      // ensure initalization is handled again
       instance = null;
     }
     if (!instance) {
@@ -31,6 +45,22 @@ function reloader(apppath, initFn) {
         instance = m;
       }
     }
-    instance(req, res, next)
+    instance(req, res, next);
   }
+
+  const proxy = new Proxy(handler, {
+    get(_target, prop) {
+      const value = instance[prop];
+      if (value instanceof Function) {
+        // any function called on proxy should be
+        // invoked on current instance
+        return function(...args) {
+          return value.apply(instance, args)
+        }
+      }
+      return value;
+    }
+  });
+
+  return proxy;
 }

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -9,12 +9,6 @@ function reloader(apppath, initFn) {
     throw new Error('Reloader requires an absolute path to module');
   }
 
-  const filepath = require.resolve(apppath);
-  const resolvedPath = path.dirname(filepath) === apppath
-    ? apppath   // apppath resolves a directory, whatch all
-    : filepath; // apppath resolves a filename, watch file
-  fileWatcher(resolvedPath);
-
   let m = null;
   let instance = null;
 
@@ -30,6 +24,12 @@ function reloader(apppath, initFn) {
     // if DERBY_HMR is not enabled
     return instance;
   }
+
+  const filepath = require.resolve(apppath);
+  const resolvedPath = path.dirname(filepath) === apppath
+    ? apppath   // apppath resolves a directory, whatch all
+    : filepath; // apppath resolves a filename, watch file
+  fileWatcher(resolvedPath);
 
   const handler = (req, res, next) => {
     if (!require.cache[apppath]) {

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -10,7 +10,7 @@ function reloader(appPath, initFn) {
   }
 
   let appModule = null;
-  let instance = null;
+  let appInstance = null;
 
   appModule = require(appPath);
   if (initFn) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,96 +5,104 @@ const path = require('path');
 
 const DerbyViewsPlugin = require('./lib/DerbyViewPlugin');
 
-module.exports = (webpack, apps, rootDir, options = {}) => ({
-  mode: 'development',
-  entry: Object.entries(apps).reduce((acc, [name, path]) => ({
-    ...acc,
-    [name]: options.hotModuleReplacement ? [
-      'webpack-hot-middleware/client',
-      path,
-    ] : [ path ],
-  }), {}),
-  node: {
-    __dirname: true,
-    __filename: true,
-  },
-  optimization: {
-    chunkIds: 'named',
-    moduleIds: 'named',
-    minimize: false,
-    concatenateModules: true,
-    runtimeChunk: 'single',
-    splitChunks: {
-      cacheGroups: {
-        ...(Object.entries(apps).reduce((acc, [name]) => ({
-          ...acc,
-          [`${name}_views`]: {
-            test: new RegExp(`[\\/]node_modules[\\/]derby[\\/]lib[\\/]${name}__views.js`),
-            name: `${name}_views`,
-            chunks: 'all',
-            priority: 20,
-          }
-        }), {})),
-        vendor: {
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendors',
-          chunks: 'all'
-        },
-      }
+module.exports = function(webpack, apps, rootDir, opts = {}) {
+  const options = {
+    hotModuleReplacement: false,
+    defines: {},
+    ...opts,
+  };
+
+  return ({
+    mode: 'development',
+    entry: Object.entries(apps).reduce((acc, [name, path]) => ({
+      ...acc,
+      [name]: options.hotModuleReplacement ? [
+        'webpack-hot-middleware/client',
+        path,
+      ] : [ path ],
+    }), {}),
+    node: {
+      __dirname: true,
+      __filename: true,
     },
-  },
-  output: {
-    filename: '[name]-[contenthash].js',
-    chunkFilename: '[id]-[chunkhash].js',
-    path: path.resolve(rootDir, 'public'),
-    clean: false,
-    publicPath: '/',
-  },
-  devtool: 'source-map',
-  module: {
-    rules: [],
-  },
-  plugins: ([
-    // order matters
-    // provide plugin before hot module replacement
-    // to ensure polyfills can be applied
-    new webpack.ProvidePlugin({
-      process: 'process/browser',
-      Buffer: ['buffer', 'Buffer'],
-    }),
-    options.hotModuleReplacement ? new webpack.HotModuleReplacementPlugin() : undefined,
-    new webpack.DefinePlugin({
-      'process.title': JSON.stringify('browser'),
-      'process.env.DERBY_HASH': JSON.stringify(process.env.DERBY_HASH || 'd3rby-h4$h'),
-      'process.browser': true,
-      'process.env.DEBUG_MIME': false,
-    }),
-    new WebpackDeduplicationPlugin({}),
-    new DerbyViewsPlugin(apps),
-    new WebpackManifestPlugin({ writeToFileEmit: true }),
-  ].filter(Boolean)),
-  resolve: {
-    extensions: ['...', '.coffee', '.ts'], // .coffee and .ts last so .js files in node_modules get precedence
-    fallback: {
-      // trailing slash required to indicate to lookup algorithm that this is not node core lib
-      events: require.resolve('events/'),
-      path: require.resolve('path-browserify'),
-      process: require.resolve('process/browser'),
-      racer: require.resolve('racer'),
-      // trailing slash required to indicate to lookup algorithm that this is not node core lib
-      buffer: require.resolve('buffer/'),
-      crypto: require.resolve('crypto-browserify'),
-      http: require.resolve('stream-http'),
-      https: require.resolve('https-browserify'),
-      stream: require.resolve('stream-browserify'),
-      os: require.resolve('os-browserify'),
-      url: require.resolve('url'),
-      constants: false,
-      fs: false,
-      zlib: false,
-      net: false,
-      tls: false,
-      vm: false,
+    optimization: {
+      chunkIds: 'named',
+      moduleIds: 'named',
+      minimize: false,
+      concatenateModules: true,
+      runtimeChunk: 'single',
+      splitChunks: {
+        cacheGroups: {
+          ...(Object.entries(apps).reduce((acc, [name]) => ({
+            ...acc,
+            [`${name}_views`]: {
+              test: new RegExp(`[\\/]node_modules[\\/]derby[\\/]lib[\\/]${name}__views.js`),
+              name: `${name}_views`,
+              chunks: 'all',
+              priority: 20,
+            }
+          }), {})),
+          vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors',
+            chunks: 'all'
+          },
+        }
+      },
     },
-  },
-});
+    output: {
+      filename: '[name]-[contenthash].js',
+      chunkFilename: '[id]-[chunkhash].js',
+      path: path.resolve(rootDir, 'public'),
+      clean: false,
+      publicPath: '/',
+    },
+    devtool: 'source-map',
+    module: {
+      rules: [],
+    },
+    plugins: ([
+      // order matters
+      // provide plugin before hot module replacement
+      // to ensure polyfills can be applied
+      new webpack.ProvidePlugin({
+        process: 'process/browser',
+        Buffer: ['buffer', 'Buffer'],
+      }),
+      options.hotModuleReplacement ? new webpack.HotModuleReplacementPlugin() : undefined,
+      new webpack.DefinePlugin({
+        'process.title': JSON.stringify('browser'),
+        'process.env.DERBY_HASH': JSON.stringify(process.env.DERBY_HASH || 'd3rby-h4$h'),
+        'process.browser': true,
+        ...options.defines,
+      }),
+      new WebpackDeduplicationPlugin({}),
+      new DerbyViewsPlugin(apps),
+      new WebpackManifestPlugin({ writeToFileEmit: true }),
+    ].filter(Boolean)),
+    resolve: {
+      extensions: ['...', '.coffee', '.ts'], // .coffee and .ts last so .js files in node_modules get precedence
+      fallback: {
+        // trailing slash required to indicate to lookup algorithm that this is not node core lib
+        events: require.resolve('events/'),
+        path: require.resolve('path-browserify'),
+        process: require.resolve('process/browser'),
+        racer: require.resolve('racer'),
+        // trailing slash required to indicate to lookup algorithm that this is not node core lib
+        buffer: require.resolve('buffer/'),
+        crypto: require.resolve('crypto-browserify'),
+        http: require.resolve('stream-http'),
+        https: require.resolve('https-browserify'),
+        stream: require.resolve('stream-browserify'),
+        os: require.resolve('os-browserify'),
+        url: require.resolve('url'),
+        constants: false,
+        fs: false,
+        zlib: false,
+        net: false,
+        tls: false,
+        vm: false,
+      },
+    },
+  });
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,8 +65,8 @@ module.exports = (webpack, apps, rootDir, options = {}) => ({
     options.hotModuleReplacement ? new webpack.HotModuleReplacementPlugin() : undefined,
     new webpack.DefinePlugin({
       'process.title': JSON.stringify('browser'),
-      'DERBY_BUNDLED_AT': JSON.stringify((new Date()).valueOf().toString()),
-      'DERBY_SCRIPT_HASH': 'm4gic_h4$h',
+      'process.env.DERBY_BUNDLED_AT': JSON.stringify((new Date()).valueOf().toString()),
+      'process.env.DERBY_HASH': JSON.stringify(process.env.DERBY_HASH || 'd3rby-h4$h'),
       'process.browser': true,
       'process.env.LEVER_NGROK_ID': 0,
       'process.env.DEBUG_MIME': false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,6 @@ module.exports = (webpack, apps, rootDir, options = {}) => ({
       'process.title': JSON.stringify('browser'),
       'process.env.DERBY_HASH': JSON.stringify(process.env.DERBY_HASH || 'd3rby-h4$h'),
       'process.browser': true,
-      'process.env.LEVER_NGROK_ID': 0,
       'process.env.DEBUG_MIME': false,
     }),
     new WebpackDeduplicationPlugin({}),
@@ -82,7 +81,6 @@ module.exports = (webpack, apps, rootDir, options = {}) => ({
       path: require.resolve('path-browserify'),
       process: require.resolve('process/browser'),
       racer: require.resolve('racer'),
-      // below added for admin2
       // trailing slash required to indicate to lookup algorithm that this is not node core lib
       buffer: require.resolve('buffer/'),
       crypto: require.resolve('crypto-browserify'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,15 @@ module.exports = (webpack, apps, rootDir, options = {}) => ({
     runtimeChunk: 'single',
     splitChunks: {
       cacheGroups: {
+        ...(Object.entries(apps).reduce((acc, [name]) => ({
+          ...acc,
+          [`${name}_views`]: {
+            test: new RegExp(`[\\/]node_modules[\\/]derby[\\/]lib[\\/]${name}__views.js`),
+            name: `${name}_views`,
+            chunks: 'all',
+            priority: 20,
+          }
+        }), {})),
         vendor: {
           test: /[\\/]node_modules[\\/]/,
           name: 'vendors',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,6 @@ module.exports = (webpack, apps, rootDir, options = {}) => ({
     options.hotModuleReplacement ? new webpack.HotModuleReplacementPlugin() : undefined,
     new webpack.DefinePlugin({
       'process.title': JSON.stringify('browser'),
-      'process.env.DERBY_BUNDLED_AT': JSON.stringify((new Date()).valueOf().toString()),
       'process.env.DERBY_HASH': JSON.stringify(process.env.DERBY_HASH || 'd3rby-h4$h'),
       'process.browser': true,
       'process.env.LEVER_NGROK_ID': 0,


### PR DESCRIPTION
- Change middleware and hot reload middleware to take configuration so consuming apps can modify configuration
- Add `reloader` to wrap and proxy express application handlers (both express apps, and Derby apps)
- Add view chunk configuration to base webpack config