### PR TITLE
Output js to derby subdirectory matching previous build behaviour

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -49,7 +49,7 @@ function plugin(app, options) {
     if (page.res.locals.webpack) {
       assets = middlewareAssets(page);
     } else {
-      assets = readManifestAssets('./public/manifest.json',);
+      assets = readManifestAssets( './public/manifest.json');
     }
     const scriptTags = assets.map(path =>
       `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${baseUrl}${path}" type="text/javascript"></script>`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,9 +53,9 @@ module.exports = function(webpack, apps, rootDir, opts = {}) {
     output: {
       filename: '[name]-[contenthash].js',
       chunkFilename: '[id]-[chunkhash].js',
-      path: path.resolve(rootDir, 'public'),
-      clean: false,
-      publicPath: '/',
+      clean: true,
+      path: path.resolve(rootDir, './public/derby'),
+      publicPath: '/derby',
     },
     devtool: 'source-map',
     module: {
@@ -78,7 +78,10 @@ module.exports = function(webpack, apps, rootDir, opts = {}) {
       }),
       new WebpackDeduplicationPlugin({}),
       new DerbyViewsPlugin(apps),
-      new WebpackManifestPlugin({ writeToFileEmit: true }),
+      new WebpackManifestPlugin({
+        writeToFileEmit: true,
+        fileName: path.resolve(rootDir, './public/manifest.json'),
+      }),
     ].filter(Boolean)),
     resolve: {
       extensions: ['...', '.coffee', '.ts'], // .coffee and .ts last so .js files in node_modules get precedence


### PR DESCRIPTION
Browserfy build output js files to `public/derby/`, so matching this behavior.