### PR TITLE
Script base fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,21 +4,31 @@ const webpackHotMiddleware = require("webpack-hot-middleware");
 
 const webpackConfig = require('./webpack.config');
 
-function derbyWebpack(apps, rootDir) {
-  const config = () => webpackConfig(webpack, apps, rootDir);
+function derbyWebpack(apps, rootDir, options) {
+  const config = () => webpackConfig(webpack, apps, rootDir, options);
 
-  const hotReloadMiddleware = resolvedConfig => webpackHotMiddleware(webpack(resolvedConfig));
-  const devMiddleware = resolvedConfig => webpackMiddleware(webpack(resolvedConfig), {
-    serverSideRender: true,
-    index: false,
-    publicPath: resolvedConfig.output.publicPath,
-    headers: (req, res, context) => {
-      const origin = req.headers['origin'];
-      if (!origin) return;
-      res.setHeader('Access-Control-Allow-Origin', origin);
-      res.setHeader('X-Derby-Webpack', 1);
-    }
-  });
+  let compilerInstance;
+  function compiler(resolvedConfig) {
+    compilerInstance = compilerInstance ?? webpack(resolvedConfig);
+    return compilerInstance;
+  }
+
+  const hotReloadMiddleware = resolvedConfig => {
+    return webpackHotMiddleware(compiler(resolvedConfig));
+  }
+  const devMiddleware = resolvedConfig => {
+    return webpackMiddleware(compiler(resolvedConfig), {
+      serverSideRender: true,
+      index: false,
+      publicPath: resolvedConfig.output.publicPath,
+      headers: (req, res, _context) => {
+        const origin = req.headers['origin'];
+        if (!origin) return;
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('X-Derby-Webpack', 1);
+      }
+    });
+  }
 
   return {
     config,

--- a/index.js
+++ b/index.js
@@ -12,6 +12,12 @@ function derbyWebpack(apps, rootDir) {
     serverSideRender: true,
     index: false,
     publicPath: resolvedConfig.output.publicPath,
+    headers: (req, res, context) => {
+      const origin = req.headers['origin'];
+      if (!origin) return;
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('X-Derby-Webpack', 1);
+    }
   });
 
   return {

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -33,11 +33,11 @@ function FileWatcher(path) {
   watcher
     .on('change', function (subpath) {
       const path = resolve(subpath);
-      console.log('---> 🔁  WATCHER CHANGE', path);
+      console.log('---> 🔁 WATCHER CHANGE', path);
       purgeRefs(path, root);
     })
     .on('ready', function () {
-      console.log('===> 🔎  watching', root);
+      console.log('===> 🔎 watching', root);
     })
 
   this.watcher = watcher;
@@ -58,9 +58,11 @@ function findChildRefs(idStr) {
 }
 
 function purgeRefs(idStr, root) {
-  if (!require.cache[idStr]) return;
-  console.log('---> 🗑️  decache', idStr);
-  decache(idStr);
+  if (!require.cache[idStr]) {
+    return;
+  }
+  console.log('---> 🗑️ decache', idStr);
+  delete require.cache[idStr];
   const markedForDecache = findChildRefs(idStr);
   markedForDecache.filter(idStr => idStr.startsWith(root))
     .forEach(idStr => {

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -5,27 +5,40 @@
  */
 const chokidar = require('chokidar');
 const resolve = require('path').resolve;
+const decache = require('decache');
+
+const watchers = new Map();
 
 module.exports = function createWatcher(path) {
-  return new FileWatcher(path);
+  if (watchers.has(path)) {
+    return watchers.get(path);
+  }
+  console.log('---> 🔍 WATCHER created', path);
+  const watcher = new FileWatcher(path);
+  watchers.set(path, watcher);
+  return watcher;
 };
 
 function FileWatcher(path) {  
-  const options = {ignored:['*.html']};
+  const options = {
+    ignored: ['*.html'],
+    useFsEvents: Boolean(JSON.parse(process.env.WATCH_FSEVENTS ?? false)),
+    usePolling: Boolean(JSON.parse(process.env.WATCH_POLL ?? false)),
+  };
 
   const watcher = chokidar.watch(path, options);
 
-  watcher.on('ready', function() {
-    const appPath = resolve(path);
-    watcher.on('change', function(subpath) {
-      Object.keys(require.cache).forEach(function(id) {
-        // CACHE INVALIDATION
-        if (id.startsWith(appPath)) {
-          delete require.cache[id];
-        }
-      });
-    });
-  });
+  watcher
+    .on('change', function (subpath) {
+      console.log('---> 🔁 WATCHER CHANGE', subpath);
+      decache(subpath);
+      findChildRefs(subpath)
+        .filter(mod => mod.id.startsWith(path))
+        .forEach(mod => decache(mod.id));
+    })
+    .on('ready', function () {
+      console.log('===> 🔎 watching', path);
+    })
 
   this.watcher = watcher;
 }
@@ -37,4 +50,9 @@ FileWatcher.prototype.on = function (event, callback) {
 
 FileWatcher.prototype.close = function () {
   this.watcher.close();
+}
+
+function findChildRefs(idStr) {
+  const entries = Object.values(require.cache);
+  return entries.filter(entry => entry.children.some(child => child.id === idStr));
 }

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -4,7 +4,6 @@
  *  does not watch anything in node_modules/ 
  */
 const chokidar = require('chokidar');
-const decache = require('decache');
 const { resolve } = require('path');
 
 const watchers = new Map();
@@ -13,7 +12,6 @@ module.exports = function createWatcher(path) {
   if (watchers.has(path)) {
     return watchers.get(path);
   }
-  console.log('---> 🔍 WATCHER created', path);
   const watcher = new FileWatcher(path);
   watchers.set(path, watcher);
   return watcher;

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -4,8 +4,8 @@
  *  does not watch anything in node_modules/ 
  */
 const chokidar = require('chokidar');
-const resolve = require('path').resolve;
 const decache = require('decache');
+const { resolve } = require('path');
 
 const watchers = new Map();
 
@@ -26,18 +26,18 @@ function FileWatcher(path) {
     usePolling: Boolean(JSON.parse(process.env.WATCH_POLL ?? false)),
   };
 
-  const watcher = chokidar.watch(path, options);
+  const root = resolve(path);
+
+  const watcher = chokidar.watch(root, options);
 
   watcher
     .on('change', function (subpath) {
-      console.log('---> 🔁 WATCHER CHANGE', subpath);
-      decache(subpath);
-      findChildRefs(subpath)
-        .filter(mod => mod.id.startsWith(path))
-        .forEach(mod => decache(mod.id));
+      const path = resolve(subpath);
+      console.log('---> 🔁  WATCHER CHANGE', path);
+      purgeRefs(path, root);
     })
     .on('ready', function () {
-      console.log('===> 🔎 watching', path);
+      console.log('===> 🔎  watching', root);
     })
 
   this.watcher = watcher;
@@ -54,5 +54,16 @@ FileWatcher.prototype.close = function () {
 
 function findChildRefs(idStr) {
   const entries = Object.values(require.cache);
-  return entries.filter(entry => entry.children.some(child => child.id === idStr));
+  return entries.filter(entry => entry.children.some(child => child.id === idStr)).map(entry => entry.id);
+}
+
+function purgeRefs(idStr, root) {
+  if (!require.cache[idStr]) return;
+  console.log('---> 🗑️  decache', idStr);
+  decache(idStr);
+  const markedForDecache = findChildRefs(idStr);
+  markedForDecache.filter(idStr => idStr.startsWith(root))
+    .forEach(idStr => {
+      purgeRefs(idStr, root);
+    });
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -23,8 +23,10 @@ function plugin(app, options) {
   function middlewareAssets(page) {
     const { devMiddleware } = page.res.locals.webpack;
     const jsonWebpackStats = devMiddleware.stats.toJson();
-    const { assetsByChunkName } = jsonWebpackStats;
+    const { assetsByChunkName, outputPath } = jsonWebpackStats;
     const publicPath = devMiddleware.options.publicPath ?? '/';
+    console.log(assetsByChunkName);
+    console.log(devMiddleware.outputFileSystem.readdirSync(outputPath));
     return Object.values(assetsByChunkName)
       .flatMap(normalizeAssets)
       .filter(key => sourcesRe.test(key))
@@ -45,19 +47,20 @@ function plugin(app, options) {
 
   app.on('htmlDone', (page) => {
     const scriptCrossOrigin = page.app.scriptCrossOrigin || false;
-    const baseUrl = page.app.scriptBaseUrl ?? '';
+    const baseUrlObj = new URL(page.app.scriptBaseUrl);
+    baseUrlObj.pathname = '';
     if (page.res.locals.webpack) {
       assets = middlewareAssets(page);
     } else {
       assets = readManifestAssets('./public/manifest.json');
     }
-    const scriptTags = assets.map(path =>
-      `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${baseUrl}${path}" type="text/javascript"></script>`
-    ).join('\n');
+    const scriptTags = assets.map(path => {
+      const scriptPath = new URL(path, baseUrl);
+      return `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${scriptPath}" type="text/javascript"></script>`
+    }).join('\n');
     page.res.write(scriptTags);
   });
 }
-
 
 function isObject(x) {
   return typeof x === 'object' && x !== null;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -47,8 +47,8 @@ function plugin(app, options) {
 
   app.on('htmlDone', (page) => {
     const scriptCrossOrigin = page.app.scriptCrossOrigin || false;
-    const baseUrlObj = new URL(page.app.scriptBaseUrl);
-    baseUrlObj.pathname = '';
+    const baseUrl = new URL(page.app.scriptBaseUrl);
+    baseUrl.pathname = '';
     if (page.res.locals.webpack) {
       assets = middlewareAssets(page);
     } else {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -12,6 +12,7 @@ function plugin(app, options) {
   const { derby } = app;
   const { App, util } = derby;
   const sourcesRe = new RegExp(`(${app.name}|${app.name}_views|vendors|common|runtime).*\.js$`);
+  const hotUpdatesRe = new RegExp('\.hot-update\.js$');
 
   App.prototype.writeScripts = function(backend, dir, options, cb) {
     this._autoRefresh(backend);
@@ -28,9 +29,10 @@ function plugin(app, options) {
     console.log(assetsByChunkName);
     console.log(devMiddleware.outputFileSystem.readdirSync(outputPath));
     return Object.values(assetsByChunkName)
-      .flatMap(normalizeAssets)
-      .filter(key => sourcesRe.test(key))
-      .map(fileName => `${publicPath}${fileName}`);
+    .flatMap(normalizeAssets)
+    .filter(key => sourcesRe.test(key))
+    .filter(fileName => !hotUpdatesRe.test(fileName))
+    .map(fileName => `${publicPath}${fileName}`);
   }
   
   function readManifestAssets(filepath) {

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -22,25 +22,29 @@ function reloader(appPath, initFn) {
     // if DERBY_HMR is not enabled
     return appInstance;
   }
-
-  const handler = (req, res, next) => {
-    if (!require.cache[appPath]) {
-      // has been evicted form require.cache
-      // ensure initalization is handled again
-      appInstance = null;
-    }
-    if (!appInstance) {
-      appModule = require(appPath);
-      if (initFn) {
-        appInstance = initFn(appModule);
-      } else {
-        appInstance = appModule;
+  
+  const handler = function (idStr) {
+    console.log('---> ♻️ RELOADABLE', idStr);
+    return function (req, res, next) {
+      console.log('---> HANDLER', req.path, idStr);
+      if (!require.cache[idStr]) {
+        // has been evicted form require.cache
+        // ensure initalization is handled again
+        appInstance = null;
       }
-    }
-    appInstance(req, res, next);
+      if (!appInstance) {
+        appModule = require(appPath);
+        if (initFn) {
+          appInstance = initFn(appModule);
+        } else {
+          appInstance = appModule;
+        }
+      }
+      appInstance(req, res, next);
+    };
   }
 
-  const proxy = new Proxy(handler, {
+  const proxy = new Proxy(handler(require.resolve(appPath)), {
     get(_target, prop) {
       const value = appInstance[prop];
       if (value instanceof Function) {

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -1,6 +1,4 @@
-const fs = require('node:fs');
 const path = require('node:path');
-const fileWatcher = require('./FileWatcher');
 
 module.exports = reloader;
 
@@ -24,12 +22,6 @@ function reloader(appPath, initFn) {
     // if DERBY_HMR is not enabled
     return appInstance;
   }
-
-  const filepath = require.resolve(appPath);
-  const resolvedPath = path.dirname(filepath) === appPath
-    ? appPath   // appPath resolves a directory, watch all
-    : filepath; // appPath resolves a filename, watch file
-  fileWatcher(resolvedPath);
 
   const handler = (req, res, next) => {
     if (!require.cache[appPath]) {

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -24,9 +24,7 @@ function reloader(appPath, initFn) {
   }
   
   const handler = function (idStr) {
-    console.log('---> ♻️ RELOADABLE', idStr);
     return function (req, res, next) {
-      console.log('---> HANDLER', req.path, idStr);
       if (!require.cache[idStr]) {
         // has been evicted form require.cache
         // ensure initalization is handled again

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "buffer": "^6.0.3",
     "chokidar": "^3.5.3",
     "crypto-browserify": "^3.12.0",
+    "decache": "^4.6.1",
     "events": "^3.3.0",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",
@@ -29,11 +30,11 @@
     "stream-http": "^3.2.0",
     "url": "^0.11.0",
     "webpack": "^5.75.0",
+    "webpack-cli": "^4.10.0",
     "webpack-deduplication-plugin": "0.0.8",
     "webpack-dev-server": "^4.10.0",
     "webpack-hot-middleware": "^2.25.2",
     "webpack-manifest-plugin": "^5.0.0",
-    "webpack-virtual-modules": "^0.4.5",
-    "webpack-cli": "^4.10.0"
+    "webpack-virtual-modules": "^0.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "buffer": "^6.0.3",
     "chokidar": "^3.5.3",
     "crypto-browserify": "^3.12.0",
-    "decache": "^4.6.1",
     "events": "^3.3.0",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,9 +57,8 @@ module.exports = function(webpack, apps, rootDir, opts = {}) {
       path: path.resolve(rootDir, './public/derby'),
       publicPath: '/derby/',
     },
-    devtool: options.hotModuleReplacement
-      ? 'eval-source-map'
-      : 'source-map',
+    // @TODO: evaluate other options for performance/precision for dev and static build
+    devtool: 'source-map',
     module: {
       rules: [],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,9 @@ module.exports = function(webpack, apps, rootDir, opts = {}) {
       path: path.resolve(rootDir, './public/derby'),
       publicPath: '/derby/',
     },
-    devtool: 'source-map',
+    devtool: options.hotModuleReplacement
+      ? 'eval-source-map'
+      : 'source-map',
     module: {
       rules: [],
     },


### PR DESCRIPTION
- Fix missed use of `scriptBaseUrl` in `plugin`
- Remove use of `FileWatcher` from `reloader` as this made for too many watchers and to narrowly scoped watcher
- Add CORS headers for middleware
- Filter out `hot-update` modules from assets when rendering page
- Fix middleware and hot reload using same compiler instance