### PR TITLE
Fixes for server reloading

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,48 +2,26 @@ const webpack = require("webpack");
 const webpackMiddleware = require("webpack-dev-middleware");
 const webpackHotMiddleware = require("webpack-hot-middleware");
 
-const webpackConfig = require('./webpack.config');
+/**
+ * Creates a webpack compiler, plus associated dev and hot reload middleware.
+ *
+ * @param {webpack.Configuration} webpackConfig
+ */
+exports.createWebpackCompiler = function getMiddleware(webpackConfig) {
+  const webpackCompiler = webpack(webpackConfig);
 
-function derbyWebpack(apps, rootDir, options) {
-  const config = () => webpackConfig(webpack, apps, rootDir, options);
+  const devMiddleware = webpackMiddleware(webpackCompiler, {
+    serverSideRender: true,
+    index: false,
+    publicPath: resolvedConfig.output.publicPath,
+    headers: (req, res, _context) => {
+      const origin = req.headers['origin'];
+      if (!origin) return;
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('X-Derby-Webpack', 1);
+    }
+  });
+  const hotReloadMiddleware = webpackHotMiddleware(webpackCompiler);
 
-  // TODO:
-  // 1. Split out a separate function for getting the base config.
-  // 2. If the hotReloadMiddleware and devMiddleware are always used together
-  //    and with the same config, then have one function that, given the config,
-  //    returns them both together with a single underlying compiler, instead
-  //    needing the cachedCompiler stuff.
-  // Both of those would be breaking changes and necessitate a major version,
-  // unless we first add them as separate functions in a minor version, then
-  // remove the current one in a major version.
-  let compilerInstance;
-  function compiler(resolvedConfig) {
-    compilerInstance = compilerInstance ?? webpack(resolvedConfig);
-    return compilerInstance;
-  }
-
-  const hotReloadMiddleware = resolvedConfig => {
-    return webpackHotMiddleware(compiler(resolvedConfig));
-  }
-  const devMiddleware = resolvedConfig => {
-    return webpackMiddleware(compiler(resolvedConfig), {
-      serverSideRender: true,
-      index: false,
-      publicPath: resolvedConfig.output.publicPath,
-      headers: (req, res, _context) => {
-        const origin = req.headers['origin'];
-        if (!origin) return;
-        res.setHeader('Access-Control-Allow-Origin', origin);
-        res.setHeader('X-Derby-Webpack', 1);
-      }
-    });
-  }
-
-  return {
-    config,
-    devMiddleware,
-    hotReloadMiddleware,
-  }
-}
-
-module.exports = derbyWebpack;
+  return { devMiddleware, hotReloadMiddleware, webpackCompiler };
+};

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -8,18 +8,25 @@ const { resolve } = require('path');
 
 const watchers = new Map();
 
-module.exports = function createWatcher(path) {
+/**
+ * Returns a recursive file watcher for the given path.
+ *
+ * @param {string} path
+ * @param {{ ignored?: string[] }} [options]
+ * @returns {FileWatcher}
+ */
+module.exports = function createWatcher(path, options) {
   if (watchers.has(path)) {
     return watchers.get(path);
   }
-  const watcher = new FileWatcher(path);
+  const watcher = new FileWatcher(path, options);
   watchers.set(path, watcher);
   return watcher;
 };
 
-function FileWatcher(path) {  
-  const options = {
-    ignored: ['*.html'],
+function FileWatcher(path, options) {  
+  const chokidarOptions = {
+    ignored: options?.ignored || ['**/*.html'],
     useFsEvents: Boolean(JSON.parse(process.env.WATCH_FSEVENTS ?? false)),
     usePolling: Boolean(JSON.parse(process.env.WATCH_POLL ?? false)),
   };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,13 +3,21 @@ const viewCache = require('./viewCache');
 
 module.exports = plugin;
 
-// - Adds on `htmlDone` handler to write js assets script tags to tail of html body
-// - Adds stub method for `writeScripts`
-function plugin(app, options) {
+function plugin(AppForServer) {
   if (process.title === 'browser') {
     // not in server
     return;
   }
+  const oldAppInit = AppForServer.prototype._init;
+  AppForServer.prototype._init = function() {
+    oldAppInit.apply(this, arguments);
+    pluginForAppInstance(this);
+  };
+}
+
+// - Adds on `htmlDone` handler to write js assets script tags to tail of html body
+// - Adds stub method for `writeScripts`
+function pluginForAppInstance(app) {
   const sourcesRe = new RegExp(`(${app.name}|${app.name}_views|vendors|common|runtime).*\.js$`);
   const hotUpdatesRe = new RegExp('\.hot-update\.js$');
 

--- a/lib/reloader.js
+++ b/lib/reloader.js
@@ -10,12 +10,17 @@ function reloader(appPath, initFn) {
   let appModule = null;
   let appInstance = null;
 
-  appModule = require(appPath);
-  if (initFn) {
-    appInstance = initFn(appModule);
-  } else {
-    appInstance = appModule;
+  function initAppInstance() {
+    if (!appInstance) {
+      appModule = require(appPath);
+      if (initFn) {
+        appInstance = initFn(appModule);
+      } else {
+        appInstance = appModule;
+      }
+    }
   }
+  initAppInstance();
 
   if (!process.env.DERBY_HMR) {
     // return un-proxied appInstance
@@ -23,27 +28,23 @@ function reloader(appPath, initFn) {
     return appInstance;
   }
   
-  const handler = function (idStr) {
-    return function (req, res, next) {
-      if (!require.cache[idStr]) {
-        // has been evicted form require.cache
-        // ensure initalization is handled again
-        appInstance = null;
-      }
-      if (!appInstance) {
-        appModule = require(appPath);
-        if (initFn) {
-          appInstance = initFn(appModule);
-        } else {
-          appInstance = appModule;
-        }
-      }
-      appInstance(req, res, next);
-    };
+  const idStr = require.resolve(appPath);
+  function reloadModuleIfNeeded() {
+    if (!require.cache[idStr]) {
+      // has been evicted form require.cache
+      // ensure initialization is handled again
+      appInstance = null;
+    }
+    initAppInstance();
+  }
+  function derbyWebpackHotReloadingMiddleware(req, res, next) {
+    reloadModuleIfNeeded();
+    appInstance(req, res, next);
   }
 
-  const proxy = new Proxy(handler(require.resolve(appPath)), {
+  const proxy = new Proxy(derbyWebpackHotReloadingMiddleware, {
     get(_target, prop) {
+      reloadModuleIfNeeded();
       const value = appInstance[prop];
       if (value instanceof Function) {
         // any function called on proxy should be


### PR DESCRIPTION
- Trigger reloads for Express Routers and other proxied calls
- Register plugin on AppForServer prototype, to catch server-reloaded apps
- Refactor index.js to take in a single config

This will be a new major version, as the latter two are breaking changes.