### PR TITLE
Fix & rename v2

### DIFF
--- a/createConfig.js
+++ b/createConfig.js
@@ -2,10 +2,11 @@
 const { WebpackDeduplicationPlugin } = require('webpack-deduplication-plugin');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const path = require('path');
+const webpack = require('webpack');
 
 const DerbyViewsPlugin = require('./lib/DerbyViewPlugin');
 
-module.exports = function(webpack, apps, rootDir, opts = {}) {
+module.exports = function createConfig(apps, rootDir, opts = {}) {
   const options = {
     hotModuleReplacement: false,
     defines: {},

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const webpackHotMiddleware = require("webpack-hot-middleware");
  *
  * @param {webpack.Configuration} webpackConfig
  */
-exports.createWebpackCompiler = function getMiddleware(webpackConfig) {
+exports.createMiddleware = function createMiddleware(webpackConfig) {
   const webpackCompiler = webpack(webpackConfig);
 
   const devMiddleware = webpackMiddleware(webpackCompiler, {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ exports.createWebpackCompiler = function getMiddleware(webpackConfig) {
   const devMiddleware = webpackMiddleware(webpackCompiler, {
     serverSideRender: true,
     index: false,
-    publicPath: resolvedConfig.output.publicPath,
+    publicPath: webpackConfig.output.publicPath,
     headers: (req, res, _context) => {
       const origin = req.headers['origin'];
       if (!origin) return;


### PR DESCRIPTION
- rename `webpack.config.js` to `createConfig` better reflecting usage and not confuse w actual `webpack.config` convention
- rename exported fn from `index` to better reflect usage in creating middleware
- fix `undefined` ref to `resolvedConfig` that was renamed to `webpackConfig`