### PR TITLE
Remove logging

### DIFF
--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -3,8 +3,8 @@
  *  only watches paths under app path
  *  does not watch anything in node_modules/ 
  */
-const chokidar = require('chokidar');
 const { resolve } = require('path');
+const chokidar = require('chokidar');
 
 const watchers = new Map();
 
@@ -24,37 +24,28 @@ module.exports = function createWatcher(path, options) {
   return watcher;
 };
 
-function FileWatcher(path, options) {  
-  const chokidarOptions = {
-    ignored: options?.ignored || ['**/*.html'],
-    useFsEvents: Boolean(JSON.parse(process.env.WATCH_FSEVENTS ?? false)),
-    usePolling: Boolean(JSON.parse(process.env.WATCH_POLL ?? false)),
-  };
+const EVENTS = {
+  decached: 'decached'
+};
 
-  const root = resolve(path);
-
-  const watcher = chokidar.watch(root, options);
-
-  watcher
-    .on('change', function (subpath) {
-      const path = resolve(subpath);
-      console.log('---> 🔁 WATCHER CHANGE', path);
-      purgeRefs(path, root);
-    })
-    .on('ready', function () {
-      console.log('===> 🔎 watching', root);
-    })
-
-  this.watcher = watcher;
-}
-
-FileWatcher.prototype.on = function (event, callback) {
-  this.watcher.on(event, callback);
-  return this;
-}
-
-FileWatcher.prototype.close = function () {
-  this.watcher.close();
+class FileWatcher extends chokidar.FSWatcher {
+  constructor(path, options) {
+    const chokidarOptions = {
+      ignored: options?.ignored || ['**/*.html'],
+      useFsEvents: Boolean(JSON.parse(process.env.WATCH_FSEVENTS ?? false)),
+      usePolling: Boolean(JSON.parse(process.env.WATCH_POLL ?? false)),
+    };
+    super(chokidarOptions);
+    const root = resolve(path);
+    this.add(root);
+    this.on('change', function (subpath) {
+      setTimeout(() => {
+        const path = resolve(subpath);
+        const purgedIds = purgeRefs(path, root);
+        this._emit(EVENTS.decached, purgedIds);
+      }, 0);
+    });
+  }
 }
 
 function findChildRefs(idStr) {
@@ -62,15 +53,16 @@ function findChildRefs(idStr) {
   return entries.filter(entry => entry.children.some(child => child.id === idStr)).map(entry => entry.id);
 }
 
-function purgeRefs(idStr, root) {
+function purgeRefs(idStr, root, purged = []) {
   if (!require.cache[idStr]) {
-    return;
+    return purged;
   }
-  console.log('---> 🗑️ decache', idStr);
   delete require.cache[idStr];
+  purged.push(idStr);
   const markedForDecache = findChildRefs(idStr);
   markedForDecache.filter(idStr => idStr.startsWith(root))
     .forEach(idStr => {
-      purgeRefs(idStr, root);
+      purgeRefs(idStr, root, purged);
     });
+  return purged;
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -36,10 +36,9 @@ function pluginForAppInstance(app) {
   function middlewareAssets(page) {
     const { devMiddleware } = page.res.locals.webpack;
     const jsonWebpackStats = devMiddleware.stats.toJson();
-    const { assetsByChunkName, outputPath } = jsonWebpackStats;
+    const { assetsByChunkName } = jsonWebpackStats;
     const publicPath = devMiddleware.options.publicPath ?? '/';
-    console.log(assetsByChunkName);
-    console.log(devMiddleware.outputFileSystem.readdirSync(outputPath));
+
     return Object.values(assetsByChunkName)
     .flatMap(normalizeAssets)
     .filter(key => sourcesRe.test(key))


### PR DESCRIPTION
- Remove usage of `console.log` for tracking activity
- Simplify watcher by extending `chokadir.FSWatcher` and using emitted events
- Add `decached` event that emits module ids (paths) removed from `require.cache`

