### PR TITLE
Refresh view JS bundle on view html changes

### DIFF
--- a/createConfig.js
+++ b/createConfig.js
@@ -37,7 +37,7 @@ module.exports = function createConfig(apps, rootDir, opts = {}) {
           ...(Object.entries(apps).reduce((acc, [name]) => ({
             ...acc,
             [`${name}_views`]: {
-              test: new RegExp(`[\\/]node_modules[\\/]derby[\\/]lib[\\/]${name}__views.js`),
+              test: new RegExp(`/derby-webpack-virtual-fs/app-views/${name}__views.js`),
               name: `${name}_views`,
               chunks: 'all',
               priority: 20,

--- a/lib/DerbyViewPlugin.js
+++ b/lib/DerbyViewPlugin.js
@@ -28,12 +28,12 @@ DerbyViewsPlugin.prototype.apply = function(compiler) {
           const viewSource = viewCache.getViewsSource(appPath);
           if (viewSource) {
             const moduleFile = `${appName}${viewsSuffix}`;
-            const modulePath = `./node_modules/derby/lib/${moduleFile}`;
-            console.log('VIEWS', appName, appPath, '===>', modulePath);
+            const modulePath = `/derby-webpack-virtual-fs/app-views/${moduleFile}`;
             virtualModules.writeModule(modulePath, viewSource);
           }
         }
         updateVirtualViewsFile();
+        viewCache.addViewUpdateListener(appPath, updateVirtualViewsFile);
       });
     }
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -3,6 +3,8 @@ if (process.title === 'browser') {
 
   App.prototype._views = function () {
     const appName = this.name;
-    return require(`derby/lib/${appName}__views`);
+    // This can't interpolate with a shared constant in another file, because then Webpack's
+    // static analysis would treat this require as having a second dynamic path segment.
+    return require(`/derby-webpack-virtual-fs/app-views/${appName}__views`);
   }
 }

--- a/lib/viewCache.js
+++ b/lib/viewCache.js
@@ -5,6 +5,9 @@ exports.registerApp = (app) => {
   cache.set(app.filename, new AppCacheEntry(app));
 };
 
+/**
+ * @param {string} appPath
+ */
 exports.getViewsSource = (appPath) => {
   if (cache.has(appPath)) {
     return cache.get(appPath).getViewsSource();
@@ -16,7 +19,21 @@ exports.getViewsSource = (appPath) => {
 exports.refreshApp = (app) => {
   const appPath = app.filename;
   if (cache.has(appPath)) {
-    cache.get(appPath).clearViewsSource();
+    cache.get(appPath).onViewUpdate();
+  } else {
+    throw new Error(`App ${appPath} wasn't registered in cache`);
+  }
+};
+
+/** @typedef {() => void} ViewUpdateListener */
+
+/**
+ * @param {string} appPath
+ * @param {ViewUpdateListener} listener
+ */
+exports.addViewUpdateListener = (appPath, listener) => {
+  if (cache.has(appPath)) {
+    cache.get(appPath).addViewUpdateListener(listener);
   } else {
     throw new Error(`App ${appPath} wasn't registered in cache`);
   }
@@ -26,6 +43,8 @@ class AppCacheEntry {
   constructor(app) {
     this.app = app;
     this.viewsSource = '';
+    /** @type {ViewUpdateListener[]} */
+    this.viewUpdateListeners = [];
   }
 
   getViewsSource() {
@@ -35,7 +54,20 @@ class AppCacheEntry {
     return this.viewsSource;
   }
 
-  clearViewsSource() {
+  onViewUpdate() {
+    // Invalidate cached viewsSource
     this.viewsSource = '';
+
+    for (const listener of this.viewUpdateListeners) {
+      listener();
+    }
+  }
+
+  /**
+   * Adds a listener that will be called when the app's views are updated.
+   * @param {ViewUpdateListener} listener
+   */
+  addViewUpdateListener(listener) {
+    this.viewUpdateListeners.push(listener);
   }
 }

--- a/lib/viewCache.js
+++ b/lib/viewCache.js
@@ -1,28 +1,41 @@
-const pathsToApps = new Map();
-const pathsToViewsSource = new Map();
+/** @type {Map<string, AppCacheEntry>} */
+const cache = new Map();
 
 exports.registerApp = (app) => {
-  pathsToApps.set(app.filename, app);
+  cache.set(app.filename, new AppCacheEntry(app));
 };
 
 exports.getViewsSource = (appPath) => {
-  if (pathsToViewsSource.has(appPath)) {
-    return pathsToViewsSource.get(appPath);
-  } else if (pathsToApps.has(appPath)) {
-    const app = pathsToApps.get(appPath);
-    const viewsSource = app._viewsSource({server: false, minify: false});
-
-    pathsToViewsSource.set(appPath, viewsSource);
-    return viewsSource;
+  if (cache.has(appPath)) {
+    return cache.get(appPath).getViewsSource();
   } else {
-    // TODO: Throw an error instead?
-    return '';
+    throw new Error(`App ${appPath} wasn't registered in cache`);
   }
 };
 
 exports.refreshApp = (app) => {
   const appPath = app.filename;
-  pathsToApps.set(appPath, app);
-  // Invalidate viewsSource cache for the app.
-  pathsToViewsSource.delete(appPath);
+  if (cache.has(appPath)) {
+    cache.get(appPath).clearViewsSource();
+  } else {
+    throw new Error(`App ${appPath} wasn't registered in cache`);
+  }
 };
+
+class AppCacheEntry {
+  constructor(app) {
+    this.app = app;
+    this.viewsSource = '';
+  }
+
+  getViewsSource() {
+    if (!this.viewsSource) {
+      this.viewsSource = this.app._viewsSource({server: false, minify: false});
+    }
+    return this.viewsSource;
+  }
+
+  clearViewsSource() {
+    this.viewsSource = '';
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "webpack-dev-server": "^4.10.0",
     "webpack-hot-middleware": "^2.25.2",
     "webpack-manifest-plugin": "^5.0.0",
-    "webpack-virtual-modules": "^0.4.5"
+    "webpack-virtual-modules": "^0.5.0"
   }
 }


### PR DESCRIPTION
This eliminates the attach errors under hot reload after modifying a HTML file, where the server was using the latest HTML views, but the client was using an older JS view bundle.


A couple non-obvious changes to explain:

1) I moved the virtual views from being under a Derby-relative `node_modules/derby/lib/`, to being under an absolute path `/derby-webpack-virtual-fs/app-views/`
    - Webpack by default treats files under node_modules as ["managed files"](https://webpack.js.org/configuration/other-options/#managedpaths). That means it trusts the containing module's package.json version when determining whether to rebuild a changed file, instead of checking the file's modification timestamp, content, etc.
    - That resulted in a difficult-to-debug issue where the virtual module update triggered a Webpack compilation, but the views file didn't actually get rebuilt.
    - By moving the virtual views files to a path outside node_modules, Webpack now correctly picks up file changes in the rebuild.

2) I also updated to webpack-virtual-modules@0.5, for compatibility with webpack@5.
    - webpack-virtual-modules@0.4 worked fine with Webpack 5 for the initial view compilation, but not for updates, because Webpack 5 changed the format of its in-memory FS timestamps.

There's also a light refactor of the internal viewCache.js file to use a single map, instead of having to bookkeep what would've been 3 separate maps.