### PR TITLE
Fix static build failing due to view caching

### DIFF
--- a/lib/DerbyViewPlugin.js
+++ b/lib/DerbyViewPlugin.js
@@ -24,8 +24,10 @@ DerbyViewsPlugin.prototype.apply = function(compiler) {
       virtualViewFilesInitialized = true;
       Object.entries(appNameToPath).forEach(([appName, requirePath]) => {
         const appPath = require.resolve(requirePath, { paths: [rootPath] });
-        const app = require(appPath);
-        viewCache.registerApp(app);
+        if (!process.env.DERBY_HMR) {
+          const app = require(appPath);
+          viewCache.registerApp(app);
+        }
         function updateVirtualViewsFile() {
           const viewSource = viewCache.getViewsSource(appPath);
           if (viewSource) {

--- a/lib/DerbyViewPlugin.js
+++ b/lib/DerbyViewPlugin.js
@@ -24,6 +24,8 @@ DerbyViewsPlugin.prototype.apply = function(compiler) {
       virtualViewFilesInitialized = true;
       Object.entries(appNameToPath).forEach(([appName, requirePath]) => {
         const appPath = require.resolve(requirePath, { paths: [rootPath] });
+        const app = require(appPath);
+        viewCache.registerApp(app);
         function updateVirtualViewsFile() {
           const viewSource = viewCache.getViewsSource(appPath);
           if (viewSource) {
@@ -33,7 +35,9 @@ DerbyViewsPlugin.prototype.apply = function(compiler) {
           }
         }
         updateVirtualViewsFile();
-        viewCache.addViewUpdateListener(appPath, updateVirtualViewsFile);
+        if (process.env.DERBY_HMR) {
+          viewCache.addViewUpdateListener(appPath, updateVirtualViewsFile);
+        }
       });
     }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -28,10 +28,12 @@ function pluginForAppInstance(app) {
     }
   }
 
-  viewCache.registerApp(app);
-  app._updateScriptViews = function() {
-    viewCache.refreshApp(this);
-  };
+  if (process.env.DERBY_HMR) {
+    viewCache.registerApp(app);
+    app._updateScriptViews = function() {
+      viewCache.refreshApp(this);
+    };
+  }
 
   function middlewareAssets(page) {
     const { devMiddleware } = page.res.locals.webpack;


### PR DESCRIPTION
Ensure listeners not added and viewCache is initialized when building static assets.
