### PR TITLE
Fixes for server file watching of linked modules

### DIFF
--- a/createConfig.js
+++ b/createConfig.js
@@ -87,20 +87,25 @@ module.exports = function createConfig(apps, rootDir, opts = {}) {
     ].filter(Boolean)),
     resolve: {
       extensions: ['...', '.coffee', '.ts'], // .coffee and .ts last so .js files in node_modules get precedence
+      /*
+       * Polyfills for core Node libraries
+       *
+       * Without these, Webpack produces errors like `Module not found: Error: Can't resolve 'url'`.
+       * Modules with trailing slashes have the same names as Node core libs. The trailing slash
+       * causes Node to skip the usual behavior of prioritizing core modules in requires.
+       */
       fallback: {
-        // trailing slash required to indicate to lookup algorithm that this is not node core lib
         events: require.resolve('events/'),
         path: require.resolve('path-browserify'),
         process: require.resolve('process/browser'),
         racer: require.resolve('racer'),
-        // trailing slash required to indicate to lookup algorithm that this is not node core lib
         buffer: require.resolve('buffer/'),
         crypto: require.resolve('crypto-browserify'),
         http: require.resolve('stream-http'),
         https: require.resolve('https-browserify'),
         stream: require.resolve('stream-browserify'),
         os: require.resolve('os-browserify'),
-        url: require.resolve('url'),
+        url: require.resolve('url/'),
         constants: false,
         fs: false,
         zlib: false,

--- a/lib/FileWatcher.js
+++ b/lib/FileWatcher.js
@@ -41,28 +41,42 @@ class FileWatcher extends chokidar.FSWatcher {
     this.on('change', function (subpath) {
       setTimeout(() => {
         const path = resolve(subpath);
-        const purgedIds = purgeRefs(path, root);
+        const purgedIds = purgeRefs(path);
         this._emit(EVENTS.decached, purgedIds);
       }, 0);
     });
   }
 }
 
-function findChildRefs(idStr) {
+/**
+ * Finds all "parents" of the specified module, i.e. all usages of the module.
+ *
+ * `module.parent` only references the *first* usage of the module.
+ *
+ * @param {string} idStr
+ * @returns {string[]} list of module ids that use the specified module
+ */
+function findParents(idStr) {
   const entries = Object.values(require.cache);
   return entries.filter(entry => entry.children.some(child => child.id === idStr)).map(entry => entry.id);
 }
 
-function purgeRefs(idStr, root, purged = []) {
+/**
+ * Removes the specified module and all its "ancestors" from the module cache.
+ *
+ * @param {string} idStr - Initial module to purge
+ * @param {string[]?} purged - Array to collect purged module ids
+ * @returns {string[]} final array of purged modules ids
+ */
+function purgeRefs(idStr, purged = []) {
   if (!require.cache[idStr]) {
     return purged;
   }
   delete require.cache[idStr];
   purged.push(idStr);
-  const markedForDecache = findChildRefs(idStr);
-  markedForDecache.filter(idStr => idStr.startsWith(root))
-    .forEach(idStr => {
-      purgeRefs(idStr, root, purged);
-    });
+  const markedForDecache = findParents(idStr);
+  markedForDecache.forEach(idStr => {
+    purgeRefs(idStr, purged);
+  });
   return purged;
 }


### PR DESCRIPTION
* Correctly specify polyfill for Node core "url" library
    - The `url` polyfill needs a trailing slash so that the resolve mechanism doesn't return Node's built-in module, similar to what's done for `events` and `buffer`.
    - I also added a more comprehensive explanatory comment.
* In server file watcher, stop filtering to modules prefixed by root path
    - With dependency tree walking implemented, the simple path filter is no longer needed, and removing it allows decaching of linked modules.