### PR TITLE
Serialized derby views for server startup

### DIFF
--- a/lib/DerbyViewPlugin.js
+++ b/lib/DerbyViewPlugin.js
@@ -26,6 +26,13 @@ DerbyViewsPlugin.prototype.apply = function(compiler) {
         const appPath = require.resolve(requirePath, { paths: [rootPath] });
         if (!process.env.DERBY_HMR) {
           const app = require(appPath);
+          // scriptUrl and scriptMapUrl need to be defined
+          // but don't matter as not used downstream
+          app.scriptUrl = `${app.name}.views.js`;
+          app.scriptMapUrl = `${app.name}.views.map.js`;
+          // writes serialized views to <app>/derby-serialized directory
+          // used to load pre-compiled views for faster server start
+          app.serialize();
           viewCache.registerApp(app);
         }
         function updateVirtualViewsFile() {

--- a/lib/DerbyViewPlugin.js
+++ b/lib/DerbyViewPlugin.js
@@ -26,13 +26,15 @@ DerbyViewsPlugin.prototype.apply = function(compiler) {
         const appPath = require.resolve(requirePath, { paths: [rootPath] });
         if (!process.env.DERBY_HMR) {
           const app = require(appPath);
-          // scriptUrl and scriptMapUrl need to be defined
-          // but don't matter as not used downstream
-          app.scriptUrl = `${app.name}.views.js`;
-          app.scriptMapUrl = `${app.name}.views.map.js`;
-          // writes serialized views to <app>/derby-serialized directory
-          // used to load pre-compiled views for faster server start
-          app.serialize();
+          if (compiler.options.mode === 'production') {
+            // scriptUrl and scriptMapUrl need to be defined
+            // but don't matter as not used downstream
+            app.scriptUrl = `${app.name}.views.js`;
+            app.scriptMapUrl = `${app.name}.views.map.js`;
+            // writes serialized views to <app>/derby-serialized directory
+            // used to load pre-compiled views for faster server start
+            app.serialize();
+          }
           viewCache.registerApp(app);
         }
         function updateVirtualViewsFile() {


### PR DESCRIPTION
When using webpack, derby was not writing pre-compiled view files so the server was parsing all view html on startup. In our case, this resulted in an additional 30+ seconds before server is ready for connections.

This change writes the view files using `app.serialize()` when building static assets.