### PR TITLE
Add resolve.symlinks: false to enable npm link to work properly

### DIFF
--- a/createConfig.js
+++ b/createConfig.js
@@ -87,6 +87,8 @@ module.exports = function createConfig(apps, rootDir, opts = {}) {
     ].filter(Boolean)),
     resolve: {
       extensions: ['...', '.coffee', '.ts'], // .coffee and .ts last so .js files in node_modules get precedence
+      // Enable below polyfills to work when `npm link`ing libraries
+      symlinks: false,
       /*
        * Polyfills for core Node libraries
        *


### PR DESCRIPTION
Webpack defaults to resolving symlinks to their destination path, which can causes errors like "Module not found: Error: Can't resolve 'process/browser' in <destination>" if a `npm link`ed destination doesn't have the polyfill modules installed.

Setting symlinks to false has Webpack treat the linked modules as nested underneath the source `node_modules` tree for resolution purposes, fixing the issue.