### PR TITLE
Add support for empty/non-specified scriptBaseUrl, add caching of manifest.json disk read

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,4 @@
-const { existsSync, readFileSync } = require('fs');
+const { readFileSync } = require('fs');
 const viewCache = require('./viewCache');
 
 module.exports = plugin;
@@ -47,31 +47,52 @@ function pluginForAppInstance(app) {
     .filter(fileName => !hotUpdatesRe.test(fileName))
     .map(fileName => `${publicPath}${fileName}`);
   }
-  
-  function readManifestAssets(filepath) {
-    if (!existsSync(filepath)) {
+
+  // In production, read JS bundle info from manifest.json.
+  // Cache it in-memory to avoid reading from disk on each request.
+  let manifestAssets;
+  function readManifestAssets() {
+    if (manifestAssets) {
+      return manifestAssets;
+    }
+    const filepath = './public/manifest.json';
+    let manifestString;
+    try {
+      manifestString = readFileSync(filepath, 'utf-8');
+    } catch {
       console.error('No manifest.json file found, and webpack middleware not available. Run pack to build static bundle before starting');
       throw new Error('Missing manifest.json');
     }
-    const manifestString = readFileSync(filepath, 'utf-8');
     const assetMap = JSON.parse(manifestString);
-    return Object.entries(assetMap)
+    manifestAssets = Object.entries(assetMap)
       .filter(([key]) => sourcesRe.test(key))
       .map(([_, value]) => value);
+    return manifestAssets;
   }
 
   app.on('htmlDone', (page) => {
     const scriptCrossOrigin = page.app.scriptCrossOrigin || false;
-    const baseUrl = new URL(page.app.scriptBaseUrl);
-    baseUrl.pathname = '';
+
+    // If scriptBaseUrl is provided, take the non-path info as the base,
+    // otherwise assume root of the same host. This assumes Webpack manifest
+    // assets are prefixed with '/'.
+    let scriptBaseUrl;
+    if (page.app.scriptBaseUrl) {
+      const parsedBaseUrl = new URL(page.app.scriptBaseUrl);
+      scriptBaseUrl = parsedBaseUrl.protocol + '//' + parsedBaseUrl.host;
+    } else {
+      scriptBaseUrl = '';
+    }
+
+    let assets;
     if (page.res.locals.webpack) {
       assets = middlewareAssets(page);
     } else {
-      assets = readManifestAssets('./public/manifest.json');
+      assets = readManifestAssets();
     }
-    const scriptTags = assets.map(path => {
-      const scriptPath = new URL(path, baseUrl);
-      return `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${scriptPath}" type="text/javascript"></script>`
+    const scriptTags = assets.map(assetUrlPath => {
+      const scriptUrl = scriptBaseUrl + assetUrlPath;
+      return `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${scriptUrl}" type="text/javascript"></script>`
     }).join('\n');
     page.res.write(scriptTags);
   });


### PR DESCRIPTION
Fixes and optimizations for writing the Derby `<script>` tag to the response during server render:

- Fix an error when `scriptBaseUrl` is empty or unspecified.
    - `new URL(scriptBaseUrl)` throws an error if the argument isn't a valid URL, so avoid calling it in that case.
    - For reference, see [derby-browserify's handling of empty `scriptBaseUrl`](https://github.com/derbyjs/derby-browserify/blob/dcd16aa54b460b6baeb67d912f38115fc48df271/index.js#L127).
- Cache manifest.json in memory to avoid reading it from disk on every request
- For the disk read, directly try reading with a catch, instead of checking if it exists first. Node's `fs` docs recommend the former to avoid potential race conditions.
