### PR TITLE
Write async script tags in initial page render

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -92,7 +92,7 @@ function pluginForAppInstance(app) {
     }
     const scriptTags = assets.map(assetUrlPath => {
       const scriptUrl = scriptBaseUrl + assetUrlPath;
-      return `<script ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${scriptUrl}" type="text/javascript"></script>`
+      return `<script async ${scriptCrossOrigin ? 'crossorigin ' : ''}src="${scriptUrl}" type="text/javascript"></script>`
     }).join('\n');
     page.res.write(scriptTags);
   });


### PR DESCRIPTION
`<script async>` tags can be downloaded in parallel, speeding up page initialization.

I tested that Webpack and Derby load fine regardless of what order scripts finish downloading in. It works even when the Webpack runtime script finishes its download last.