### PR TITLE
Include derby-webpack browser shim automatically for every entry point

### DIFF
--- a/createConfig.js
+++ b/createConfig.js
@@ -19,8 +19,12 @@ module.exports = function createConfig(apps, rootDir, opts = {}) {
       ...acc,
       [name]: options.hotModuleReplacement ? [
         'webpack-hot-middleware/client',
+        '@derbyjs/derby-webpack/lib/browser',
         path,
-      ] : [ path ],
+      ] : [
+        '@derbyjs/derby-webpack/lib/browser',
+        path,
+      ],
     }), {}),
     node: {
       __dirname: true,


### PR DESCRIPTION
Previously the client-side entry point would have to explicitly require shim. Including as part of entry point configuration ensures it is requried.