### PR TITLE
Config workaround for an error processing async@3's dist/async.mjs

### DIFF
--- a/createConfig.js
+++ b/createConfig.js
@@ -65,7 +65,20 @@ module.exports = function createConfig(apps, rootDir, opts = {}) {
     // @TODO: evaluate other options for performance/precision for dev and static build
     devtool: 'source-map',
     module: {
-      rules: [],
+      rules: [
+        // Workaround for Webpack error when processing the async@3's ESM code dist/async.mjs:
+        // "The request 'process/browser' failed to resolve only because it was resolved as fully specified"
+        // https://github.com/webpack/webpack/issues/11467#issuecomment-691873586
+        //
+        // If the `fullySpecified: false` option is removed in the future, an alternative could be to use
+        // `resolve.mainFields` to have Webpack prefer the CommonJS versions of packages over the ESM versions.
+        {
+          test: /\.m?js/,
+          resolve: {
+            fullySpecified: false
+          }
+        }
+      ],
     },
     plugins: ([
       // order matters


### PR DESCRIPTION
async@3 includes an ESM version dist/async.mjs, which Webpack by default prefers over the CommonJS version dist/async.js. Unfortunately, Webpack fails to compile the mjs version with the following error:

```
ERROR in ./node_modules/sharedb/node_modules/async/dist/async.mjs 61:25-32
Module not found: Error: Can't resolve 'process/browser' in './node_modules/sharedb/node_modules/async/dist'
Did you mean 'browser.js'?
BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

Derby's run into the issue as of today with sharedb@4.0.1 upgrading from async@2 to async@3.

This workaround suggested in https://github.com/webpack/webpack/issues/11467#issuecomment-691873586 resolves the error, at least while Webpack supports the `fullySpecified: false` config.