### PR TITLE
Use new AppForClient in derby@4 if present

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,7 @@
 if (process.title === 'browser') {
-  const App = require('derby/App').App;
+  const AppModule = require('derby/App');
+  // AppForClient introduced in derby@4
+  const App = AppModule.AppForClient || AppModule.App;
 
   App.prototype._views = function () {
     const appName = this.name;


### PR DESCRIPTION
derby@4 moves client-only logic into a new AppForClient subclass, so the derby-webpack override of `_views()` needs to happen on the subclass. This falls back to using App for backwards compatibility.

Without this, derby's App.js produces an error on client attach:
```
Uncaught TypeError: this._views(...) is not a function
```